### PR TITLE
Add parameter to generate blocks for Tapyrus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1059,6 +1059,11 @@
         "has-flag": "^3.0.0"
       }
     },
+    "tapyrus-ops": {
+      "version": "git+https://github.com/chaintope/tapyrus-ops.git#6bc6314e425b1ff7f586deb02fc007daac7793c4",
+      "from": "git+https://github.com/chaintope/tapyrus-ops.git",
+      "dev": true
+    },
     "tapyrusjs-lib": {
       "version": "git+https://github.com/chaintope/tapyrusjs-lib.git#533d6c2e6d0aa4111f7948b1c12003cf6ef83137",
       "from": "git+https://github.com/chaintope/tapyrusjs-lib.git",
@@ -1068,14 +1073,14 @@
         "bip174": "^2.0.1",
         "bip32": "^2.0.4",
         "bip66": "^1.1.0",
-        "bitcoin-ops": "^1.4.0",
         "bs58check": "^2.0.0",
         "create-hash": "^1.1.0",
         "create-hmac": "^1.1.3",
         "merkle-lib": "^2.0.10",
         "pushdata-bitcoin": "^1.0.1",
         "randombytes": "^2.0.1",
-        "tiny-secp256k1": "^1.1.1",
+        "tapyrus-ops": "git+https://github.com/chaintope/tapyrus-ops.git",
+        "tiny-secp256k1": "^1.1.4",
         "typeforce": "^1.11.3",
         "varuint-bitcoin": "^1.0.4",
         "wif": "^2.0.1"
@@ -1145,9 +1150,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
+      "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
       "dev": true
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "prettier": "^1.16.4",
     "rimraf": "^2.6.3",
     "tslint": "^5.15.0",
-    "typescript": "^3.4.2"
+    "typescript": "4.1.2"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
+exports.RegtestUtils = void 0;
 const assert = require('assert');
 const rng = require('randombytes');
 const bs58check = require('bs58check');

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,8 @@ class RegtestUtils {
     this._APIURL =
       (_opts || {}).APIURL || process.env.APIURL || 'http://127.0.0.1:8080/1';
     this._APIPASS = (_opts || {}).APIPASS || process.env.APIPASS || 'satoshi';
+    this._PRIVATE_KEY =
+      (_opts || {}).PRIVATE_KEY || process.env.PRIVATE_KEY || '';
     // regtest network parameters
     this.network = {
       messagePrefix: '\x18Tapyrus Signed Message:\n',
@@ -51,7 +53,7 @@ class RegtestUtils {
   async mine(count) {
     return this.dhttp({
       method: 'POST',
-      url: `${this._APIURL}/r/generate?count=${count}&key=${this._APIPASS}`,
+      url: `${this._APIURL}/r/generate?count=${count}&key=${this._APIPASS}&priv=${this._PRIVATE_KEY}`,
     });
   }
   async height() {

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -60,6 +60,7 @@ interface Transaction {
 interface RegUtilOpts {
   APIPASS?: string;
   APIURL?: string;
+  PRIVATE_KEY?: string;
 }
 
 const dhttpCallback = require('dhttp/200');
@@ -70,11 +71,14 @@ export class RegtestUtils {
   network: Network;
   private _APIURL: string;
   private _APIPASS: string;
+  private _PRIVATE_KEY: string;
 
   constructor(_opts?: RegUtilOpts) {
     this._APIURL =
       (_opts || {}).APIURL || process.env.APIURL || 'http://127.0.0.1:8080/1';
     this._APIPASS = (_opts || {}).APIPASS || process.env.APIPASS || 'satoshi';
+    this._PRIVATE_KEY =
+      (_opts || {}).PRIVATE_KEY || process.env.PRIVATE_KEY || '';
     // regtest network parameters
     this.network = {
       messagePrefix: '\x18Tapyrus Signed Message:\n',
@@ -119,7 +123,7 @@ export class RegtestUtils {
   async mine(count: number): Promise<string[]> {
     return this.dhttp({
       method: 'POST',
-      url: `${this._APIURL}/r/generate?count=${count}&key=${this._APIPASS}`,
+      url: `${this._APIURL}/r/generate?count=${count}&key=${this._APIPASS}&priv=${this._PRIVATE_KEY}`,
     }) as Promise<string[]>;
   }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -49,11 +49,13 @@ interface Transaction {
 interface RegUtilOpts {
     APIPASS?: string;
     APIURL?: string;
+    PRIVATE_KEY?: string;
 }
 export declare class RegtestUtils {
     network: Network;
     private _APIURL;
     private _APIPASS;
+    private _PRIVATE_KEY;
     constructor(_opts?: RegUtilOpts);
     get RANDOM_ADDRESS(): string;
     dhttp(options: Request): Promise<DhttpResponse>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -55,7 +55,7 @@ export declare class RegtestUtils {
     private _APIURL;
     private _APIPASS;
     constructor(_opts?: RegUtilOpts);
-    readonly RANDOM_ADDRESS: string;
+    get RANDOM_ADDRESS(): string;
     dhttp(options: Request): Promise<DhttpResponse>;
     broadcast(txHex: string): Promise<null>;
     mine(count: number): Promise<string[]>;


### PR DESCRIPTION
Tapyrus needs an aggregated private key to generate blocks with 'generatetoaddress' rpc
This PR add the parameter "priv" when the application sent the '/r/generate' request to tapyrus-dev-server(https://github.com/chaintope/tapyrusjs-dev-server).
